### PR TITLE
removing another offending enum with space

### DIFF
--- a/bio-cwl-tools/STAR/STAR-Align.cwl
+++ b/bio-cwl-tools/STAR/STAR-Align.cwl
@@ -191,7 +191,6 @@ inputs:
        symbols:
         - None
         - Within
-        - "Within KeepPairs"
     inputBinding:
       prefix: "--outSAMunmapped"
 


### PR DESCRIPTION
thankfully not needed by our example